### PR TITLE
reference hibernateSpaceDataSource does not exist

### DIFF
--- a/site/content/xap102/asynchronous-persistency-with-the-mirror.markdown
+++ b/site/content/xap102/asynchronous-persistency-with-the-mirror.markdown
@@ -67,7 +67,7 @@ The Data-Grid Space settings would look like this:
 
 
 ```xml
-<bean id="hibernateDataSource" class="org.openspaces.persistency.hibernate.DefaultHibernateSpaceDataSourceFactoryBean">
+<bean id="hibernateSpaceDataSource" class="org.openspaces.persistency.hibernate.DefaultHibernateSpaceDataSourceFactoryBean">
     <property name="sessionFactory" ref="sessionFactory"/>
 </bean>
 


### PR DESCRIPTION
Renaming the bean hibernateDataSource to hibernateSpaceDataSource to match the reference in the os-core:embedded-space.
