### PR TITLE
waitForAtLeastOne() added

### DIFF
--- a/site/content/xap102/deploying-onto-the-service-grid.markdown
+++ b/site/content/xap102/deploying-onto-the-service-grid.markdown
@@ -54,7 +54,7 @@ Deploying via code is done using the GigaSpaces [Admin API](./administration-and
 ```java
 Admin admin = new AdminFactory().addGroup("myGroup").create();
 File puArchive = new File("/opt/gigaspaces/myPU.jar");
-ProcessingUnit pu = admin.getGridServiceManagers().deploy(
+ProcessingUnit pu = admin.getGridServiceManagers().waitForAtLeastOne().deploy(
     new ProcessingUnitDeployment(puArchive));
 ```
 


### PR DESCRIPTION
Without this the code gives the below error:

Also, the examples referenced in administration-and-monitoring-api.html include waitForAtLeastOne().

Exception in thread "main" org.openspaces.admin.AdminException: No Grid Service Manager found to deploy [C:\Temp\spacetest.jar]
    at org.openspaces.admin.internal.gsm.DefaultGridServiceManagers.deploy(DefaultGridServiceManagers.java:231)
    at com.samples.GridServiceManagerExample.deploy2(GridServiceManagerExample.java:55)
    at com.samples.GridServiceManagerExample.main(GridServiceManagerExample.java:61)
