### PR TITLE
Broken link

### DIFF
--- a/site/content/xap110/cpp-api-mapping-file.markdown
+++ b/site/content/xap110/cpp-api-mapping-file.markdown
@@ -19,7 +19,7 @@ The `type` property is mandatory in case the `property` element is defined.
 The gs.xml file allows you to define c++ classes in the space. To learn how to do this, see the [CPP API Code Generator](./cpp-api-code-generator.html) section.
 
 {{%refer%}}
-For the latest supported configurations please consult the [api documentation](/api_documentation/xap-{{%currentversion%}}.html)
+For the latest supported configurations please consult the [api documentation](/api_documentation/)
 {{%/refer%}}
 
 The `*.gs.xml` configuration needs to reside in a `<Root Folder>\config\mapping` folder where the `<Root Folder>` should be part of the application classpath.


### PR DESCRIPTION
Broken link. APIs for all versions seem to be listed on a single page now; removing reference to version specific page.
