### PR TITLE
Broken link

### DIFF
--- a/site/content/xap110/archive-container.markdown
+++ b/site/content/xap110/archive-container.markdown
@@ -223,7 +223,7 @@ configurer.destroy();
 {{% /tabs %}}
 
 {{%note%}}
-For all possible Spring configuration options see the [schema definitions](/api_documentation/xap-{{%currentversion%}}.html#schemas)
+For all possible Spring configuration options see the [schema definitions](/api_documentation/)
 {{%/note%}}
 
 


### PR DESCRIPTION
Broken link. API and schemas references are located on a single page now.
