### PR TITLE
Small change in the gs-webui

### DIFF
--- a/site/content/xap102tut/interactive-api-guide.markdown
+++ b/site/content/xap102tut/interactive-api-guide.markdown
@@ -367,13 +367,13 @@ You can start XAP's console and inspect the Data Grid components that have been 
 {{%tab "  Unix"%}}
 
 ```bash
-<GS_HOME>/bin/gs_webui.sh
+<GS_HOME>/bin/gs-webui.sh
 ```
 {{% /tab %}}
 {{%tab "  Windows"%}}
 
 ```bash
-<GS_HOME>\bin\gs_webui.bat
+<GS_HOME>\bin\gs-webui.bat
 ```
 {{% /tab %}}
 {{% /tabs %}}


### PR DESCRIPTION
Current version (xap-premium-10.2.1-ga) does not hold the files gs_webui .bat/.sh) but rather gs-webui .bat/.sh
