### PR TITLE
Update hibernate-space-persistency.markdown

### DIFF
--- a/site/content/xap110/hibernate-space-persistency.markdown
+++ b/site/content/xap110/hibernate-space-persistency.markdown
@@ -143,7 +143,7 @@ When using annotations to decorate the Space Classes the `sessionFactory` would 
 
 
 ```xml
-<bean id="sessionFactory" class="org.springframework.orm.hibernate4.annotation.AnnotationSessionFactoryBean">
+<bean id="sessionFactory" class="org.springframework.orm.hibernate4.LocalSessionFactoryBean">
     <property name="dataSource" ref="dataSource"/>
     <property name="annotatedClasses">
         <list>


### PR DESCRIPTION
org.springframework.orm.hibernate4.annotation.AnnotationSessionFactoryBean does not exist, correcting to org.springframework.orm.hibernate4.LocalSessionFactoryBean. This also will match the other example in the page already using LocalSessionFactoryBean.
