### PR TITLE
Update pojo-support.markdown

### DIFF
--- a/site/content/xap110/pojo-support.markdown
+++ b/site/content/xap110/pojo-support.markdown
@@ -69,7 +69,9 @@ public class Person {
     private int age;
 
     ...
-    public Person() {}
+    public Person() {
+     this.age = -1;
+    }
 
     @SpaceId(autoGenerate=false)
     @SpaceRouting


### PR DESCRIPTION
From the same doc: `It is recommended that the initial value (assigned in the constructor) for this field matches the null value. This enables you to quickly create new instances, and use them as templates for template matching, without changing any property except the ones you want to use for matching.`
