### PR TITLE
Patch 49

### DIFF
--- a/site/content/release_notes/101third-party.markdown
+++ b/site/content/release_notes/101third-party.markdown
@@ -35,13 +35,13 @@ This page list all the 3rd party libraries shipped with GigaSpaces XAP on a per 
 | Product | Version | License | Component | Documentation |
 |:--------|:--------|:--------|:----------|:--------------|
 | [OpenJPA](http://openjpa.apache.org/)      | 2.0.1 | [Apache2](http://openjpa.apache.org/license.html) | Persistency | [JPA](/xap101/jpa-api-overview.html) |
-| [Hibernate](http://www.hibernate.org/orm/) | 3.6.1 | [LGPL](http://hibernate.org/community/license/)          | Persistency | [Hibernate Space Persistency](/xap101/hibernate-space-persistency.html) |
+| [Hibernate](http://www.hibernate.org/orm/) | 4.1.9 | [LGPL](http://hibernate.org/community/license/)          | Persistency | [Hibernate Space Persistency](/xap101/hibernate-space-persistency.html) |
 | [Cassandra](http://cassandra.apache.org/)  | 1.1.6 | [Apache2](http://www.apache.org/licenses/LICENSE-2.0.html) |Persistency | [Cassandra Integration](/xap101/cassandra.html) |
 | [MongoDB](http://www.mongodb.org/)         | 2.11.2 | [Creative Commons](http://creativecommons.org/licenses/by-nc-sa/3.0/) | Persistency | [MongoDB Integration](/xap101/mongodb.html) |
 | [InfluxDB](https://influxdata.com/) | 0.8 | [MIT](https://influxdb.com/docs/v0.9/about/licenses.html) | Metrics | [InfluxDB] (/xap101adm/metrics-influxdb-reporter.html) |
 | [Jetty](http://eclipse.org/jetty/)         | 8.1.8, 9.1.3 | [Apache2](http://www.eclipse.org/jetty/licenses.php) | Web Container | [Jetty Processing Unit Container](/xap101/web-jetty-processing-unit-container.html) |
 | [JMS](http://java.sun.com/products/jms/)   | 1.1 | [Sun](http://www.opensource.org/licenses/sunpublic.php) | JMS | [JMS Messaging Support](/xap101/messaging-support.html) |
-| [Mule](http://www.mulesoft.org/)           | 3.3.0 | [CPAL](http://www.mulesoft.org/licensing-mule-esb) | Mule | [Mule ESB](/xap100/mule-esb.html) |
+| [Mule](http://www.mulesoft.org/)           | 3.3.0 | [CPAL](http://www.mulesoft.org/licensing-mule-esb) | Mule | [Mule ESB](/xap101/mule-esb.html) |
 | [Groovy](http://groovy-lang.org/)          | 1.8.6 | [Apache2](http://svn.codehaus.org/groovy/trunk/groovy/groovy-core/LICENSE.txt) | Dynamic Scripting | [Dynamic Scripting Support](/xap101/dynamic-language-tasks.html)|
 | [Scala](http://www.scala-lang.org/)        | 2.10.1 | [Scala](http://www.scala-lang.org/license.html) | Scala | [Scala](/xap101/scala.html) |
 | [MapDB](http://www.mapdb.org/) | 1.0.7     | [Apache2](https://github.com/jankotek/MapDB/blob/master/license.txt) | Off Heap | [Off Heap RAM](/xap101adm/memoryxtend-ohr.html) |

--- a/site/content/release_notes/102third-party.markdown
+++ b/site/content/release_notes/102third-party.markdown
@@ -34,19 +34,19 @@ This page list all the 3rd party libraries shipped with GigaSpaces XAP on a per 
 
 | Product | Version | License | Component | Documentation |
 |:--------|:--------|:--------|:----------|:--------------|
-|[OpenJPA](http://openjpa.apache.org/)      | 2.0.1 | [Apache2](http://openjpa.apache.org/license.html)          | Persistency | [JPA](/xap101/jpa-api-overview.html) |
-|[Hibernate](http://www.hibernate.org/orm/) | 3.6.1 | [LGPL](http://hibernate.org/community/license/)            | Persistency | [Hibernate Space Persistency](/xap101/hibernate-space-persistency.html) |
-|[Cassandra](http://cassandra.apache.org/)  | 1.1.6 | [Apache2](http://www.apache.org/licenses/LICENSE-2.0.html) |Persistency | [Cassandra Integration](/xap101/cassandra.html) |
-|[MongoDB](http://www.mongodb.org/)         | 2.11.2 | [Creative Commons](http://creativecommons.org/licenses/by-nc-sa/3.0/) | Persistency | [MongoDB Integration](/xap101/mongodb.html) |
+|[OpenJPA](http://openjpa.apache.org/)      | 2.0.1 | [Apache2](http://openjpa.apache.org/license.html)          | Persistency | [JPA](/xap102/jpa-api-overview.html) |
+|[Hibernate](http://www.hibernate.org/orm/) | 4.1.9 | [LGPL](http://hibernate.org/community/license/)            | Persistency | [Hibernate Space Persistency](/xap102/hibernate-space-persistency.html) |
+|[Cassandra](http://cassandra.apache.org/)  | 1.1.6 | [Apache2](http://www.apache.org/licenses/LICENSE-2.0.html) |Persistency | [Cassandra Integration](/xap102/cassandra.html) |
+|[MongoDB](http://www.mongodb.org/)         | 2.11.2 | [Creative Commons](http://creativecommons.org/licenses/by-nc-sa/3.0/) | Persistency | [MongoDB Integration](/xap102/mongodb.html) |
 |[InfluxDB](https://influxdata.com/) | 0.9 (As of 10.2.1, 0.8 for 10.2.0) | [MIT](https://influxdb.com/docs/v0.9/about/licenses.html) | Metrics | [InfluxDB](/xap102adm/metrics-influxdb-reporter.html) |
-|[Jetty](http://eclipse.org/jetty/)         | 8.1.8, 9.1.3 | [Apache2](http://www.eclipse.org/jetty/licenses.php) | Web Container | [Jetty Processing Unit Container](/xap101/web-jetty-processing-unit-container.html) |
-|[JMS](http://java.sun.com/products/jms/)   | 1.1 | [Sun](http://www.opensource.org/licenses/sunpublic.php) | JMS | [JMS Messaging Support](/xap101/messaging-support.html) |
-|[Mule](http://www.mulesoft.org/)           | 3.3.0 | [CPAL](http://www.mulesoft.org/licensing-mule-esb) | Mule | [Mule ESB](/xap100/mule-esb.html) |
-|[Groovy](http://groovy-lang.org/)          | 1.8.6 | [Apache2](http://svn.codehaus.org/groovy/trunk/groovy/groovy-core/LICENSE.txt) | Dynamic Scripting | [Dynamic Scripting Support](/xap101/dynamic-language-tasks.html)|
-|[Scala](http://www.scala-lang.org/)        | 2.10.1 | [Scala](http://www.scala-lang.org/license.html) | Scala | [Scala](/xap101/scala.html) |
-|[MapDB](http://www.mapdb.org/)             | 1.0.7 | [Apache2](https://github.com/jankotek/MapDB/blob/master/license.txt) | Off Heap | [Off Heap RAM](/xap101adm/memoryxtend-ohr.html) |
-|[snmp4j](http://www.snmp4j.org/)           | 1.11.2 | [Apache2](http://www.snmp4j.org/LICENSE-2_0.txt) | SNMP | [SNMP Connectivity via Alert Logging Gateway](/xap101/snmp-connectivity-via-alert-logging-gateway.html) |
-|[log4j-snmp-trap-appender](http://code.google.com/p/log4j-snmp-trap-appender/) | 1.2.9 | [Apache2](http://www.apache.org/licenses/LICENSE-2.0.html) | SNMP | [SNMP Connectivity via Alert Logging Gateway](/xap101/snmp-connectivity-via-alert-logging-gateway.html)  |
+|[Jetty](http://eclipse.org/jetty/)         | 8.1.8, 9.1.3 | [Apache2](http://www.eclipse.org/jetty/licenses.php) | Web Container | [Jetty Processing Unit Container](/xap102/web-jetty-processing-unit-container.html) |
+|[JMS](http://java.sun.com/products/jms/)   | 1.1 | [Sun](http://www.opensource.org/licenses/sunpublic.php) | JMS | [JMS Messaging Support](/xap102/messaging-support.html) |
+|[Mule](http://www.mulesoft.org/)           | 3.3.0 | [CPAL](http://www.mulesoft.org/licensing-mule-esb) | Mule | [Mule ESB](/xap102/mule-esb.html) |
+|[Groovy](http://groovy-lang.org/)          | 1.8.6 | [Apache2](http://svn.codehaus.org/groovy/trunk/groovy/groovy-core/LICENSE.txt) | Dynamic Scripting | [Dynamic Scripting Support](/xap102/dynamic-language-tasks.html)|
+|[Scala](http://www.scala-lang.org/)        | 2.10.1 | [Scala](http://www.scala-lang.org/license.html) | Scala | [Scala](/xap102/scala.html) |
+|[MapDB](http://www.mapdb.org/)             | 1.0.7 | [Apache2](https://github.com/jankotek/MapDB/blob/master/license.txt) | Off Heap | [Off Heap RAM](/xap102adm/memoryxtend-ohr.html) |
+|[snmp4j](http://www.snmp4j.org/)           | 1.11.2 | [Apache2](http://www.snmp4j.org/LICENSE-2_0.txt) | SNMP | [SNMP Connectivity via Alert Logging Gateway](/xap102/snmp-connectivity-via-alert-logging-gateway.html) |
+|[log4j-snmp-trap-appender](http://code.google.com/p/log4j-snmp-trap-appender/) | 1.2.9 | [Apache2](http://www.apache.org/licenses/LICENSE-2.0.html) | SNMP | [SNMP Connectivity via Alert Logging Gateway](/xap102/snmp-connectivity-via-alert-logging-gateway.html)  |
 
 {{% /tab %}}
 

--- a/site/content/release_notes/110third-party.markdown
+++ b/site/content/release_notes/110third-party.markdown
@@ -34,19 +34,19 @@ This page list all the 3rd party libraries shipped with GigaSpaces XAP on a per 
 
 | Product | Version | License | Component | Documentation |
 |:--------|:--------|:--------|:----------|:--------------|
-|[OpenJPA](http://openjpa.apache.org/)      | 2.0.1 | [Apache2](http://openjpa.apache.org/license.html)          | Persistency | [JPA](/xap101/jpa-api-overview.html) |
-|[Hibernate](http://www.hibernate.org/orm/) | 3.6.1 | [LGPL](http://hibernate.org/community/license/)            | Persistency | [Hibernate Space Persistency](/xap101/hibernate-space-persistency.html) |
-|[Cassandra](http://cassandra.apache.org/)  | 1.1.6 | [Apache2](http://www.apache.org/licenses/LICENSE-2.0.html) |Persistency | [Cassandra Integration](/xap101/cassandra.html) |
-|[MongoDB](http://www.mongodb.org/)         | 2.11.2 | [Creative Commons](http://creativecommons.org/licenses/by-nc-sa/3.0/) | Persistency | [MongoDB Integration](/xap101/mongodb.html) |
-|[InfluxDB](https://influxdata.com/) | 0.9 (As of 10.2.1, 0.8 for 10.2.0) | [MIT](https://influxdb.com/docs/v0.9/about/licenses.html) | Metrics | [InfluxDB](/xap102adm/metrics-influxdb-reporter.html) |
-|[Jetty](http://eclipse.org/jetty/)         | 8.1.8, 9.1.3 | [Apache2](http://www.eclipse.org/jetty/licenses.php) | Web Container | [Jetty Processing Unit Container](/xap101/web-jetty-processing-unit-container.html) |
-|[JMS](http://java.sun.com/products/jms/)   | 1.1 | [Sun](http://www.opensource.org/licenses/sunpublic.php) | JMS | [JMS Messaging Support](/xap101/messaging-support.html) |
-|[Mule](http://www.mulesoft.org/)           | 3.3.0 | [CPAL](http://www.mulesoft.org/licensing-mule-esb) | Mule | [Mule ESB](/xap100/mule-esb.html) |
-|[Groovy](http://groovy-lang.org/)          | 1.8.6 | [Apache2](http://svn.codehaus.org/groovy/trunk/groovy/groovy-core/LICENSE.txt) | Dynamic Scripting | [Dynamic Scripting Support](/xap101/dynamic-language-tasks.html)|
-|[Scala](http://www.scala-lang.org/)        | 2.10.1 | [Scala](http://www.scala-lang.org/license.html) | Scala | [Scala](/xap101/scala.html) |
-|[MapDB](http://www.mapdb.org/)             | 1.0.7 | [Apache2](https://github.com/jankotek/MapDB/blob/master/license.txt) | Off Heap | [Off Heap RAM](/xap101adm/memoryxtend-ohr.html) |
-|[snmp4j](http://www.snmp4j.org/)           | 1.11.2 | [Apache2](http://www.snmp4j.org/LICENSE-2_0.txt) | SNMP | [SNMP Connectivity via Alert Logging Gateway](/xap101/snmp-connectivity-via-alert-logging-gateway.html) |
-|[log4j-snmp-trap-appender](http://code.google.com/p/log4j-snmp-trap-appender/) | 1.2.9 | [Apache2](http://www.apache.org/licenses/LICENSE-2.0.html) | SNMP | [SNMP Connectivity via Alert Logging Gateway](/xap101/snmp-connectivity-via-alert-logging-gateway.html)  |
+|[OpenJPA](http://openjpa.apache.org/)      | 2.0.1 | [Apache2](http://openjpa.apache.org/license.html)          | Persistency | [JPA](/xap110/jpa-api-overview.html) |
+|[Hibernate](http://www.hibernate.org/orm/) | 4.1.9 | [LGPL](http://hibernate.org/community/license/)            | Persistency | [Hibernate Space Persistency](/xap110/hibernate-space-persistency.html) |
+|[Cassandra](http://cassandra.apache.org/)  | 1.1.6 | [Apache2](http://www.apache.org/licenses/LICENSE-2.0.html) |Persistency | [Cassandra Integration](/xap110/cassandra.html) |
+|[MongoDB](http://www.mongodb.org/)         | 2.11.2 | [Creative Commons](http://creativecommons.org/licenses/by-nc-sa/3.0/) | Persistency | [MongoDB Integration](/xap110/mongodb.html) |
+|[InfluxDB](https://influxdata.com/) | 0.9 (As of 10.2.1, 0.8 for 10.2.0) | [MIT](https://influxdb.com/docs/v0.9/about/licenses.html) | Metrics | [InfluxDB](/xap110adm/metrics-influxdb-reporter.html) |
+|[Jetty](http://eclipse.org/jetty/)         | 8.1.8, 9.1.3 | [Apache2](http://www.eclipse.org/jetty/licenses.php) | Web Container | [Jetty Processing Unit Container](/xap110/web-jetty-processing-unit-container.html) |
+|[JMS](http://java.sun.com/products/jms/)   | 1.1 | [Sun](http://www.opensource.org/licenses/sunpublic.php) | JMS | [JMS Messaging Support](/xap110/messaging-support.html) |
+|[Mule](http://www.mulesoft.org/)           | 3.3.0 | [CPAL](http://www.mulesoft.org/licensing-mule-esb) | Mule | [Mule ESB](/xap110/mule-esb.html) |
+|[Groovy](http://groovy-lang.org/)          | 1.8.6 | [Apache2](http://svn.codehaus.org/groovy/trunk/groovy/groovy-core/LICENSE.txt) | Dynamic Scripting | [Dynamic Scripting Support](/xap110/dynamic-language-tasks.html)|
+|[Scala](http://www.scala-lang.org/)        | 2.10.1 | [Scala](http://www.scala-lang.org/license.html) | Scala | [Scala](/xap110/scala.html) |
+|[MapDB](http://www.mapdb.org/)             | 1.0.7 | [Apache2](https://github.com/jankotek/MapDB/blob/master/license.txt) | Off Heap | [Off Heap RAM](/xap110adm/memoryxtend-ohr.html) |
+|[snmp4j](http://www.snmp4j.org/)           | 1.11.2 | [Apache2](http://www.snmp4j.org/LICENSE-2_0.txt) | SNMP | [SNMP Connectivity via Alert Logging Gateway](/xap110/snmp-connectivity-via-alert-logging-gateway.html) |
+|[log4j-snmp-trap-appender](http://code.google.com/p/log4j-snmp-trap-appender/) | 1.2.9 | [Apache2](http://www.apache.org/licenses/LICENSE-2.0.html) | SNMP | [SNMP Connectivity via Alert Logging Gateway](/xap110/snmp-connectivity-via-alert-logging-gateway.html)  |
 
 {{% /tab %}}
 

--- a/site/content/release_notes/120third-party.markdown
+++ b/site/content/release_notes/120third-party.markdown
@@ -34,19 +34,19 @@ This page list all the 3rd party libraries shipped with   XAP on a per version b
 
 | Product | Version | License | Component | Documentation |
 |:--------|:--------|:--------|:----------|:--------------|
-|[OpenJPA](http://openjpa.apache.org/)      | 2.0.1 | [Apache2](http://openjpa.apache.org/license.html)          | Persistency | [JPA](/xap101/jpa-api-overview.html) |
-|[Hibernate](http://www.hibernate.org/orm/) | 3.6.1 | [LGPL](http://hibernate.org/community/license/)            | Persistency | [Hibernate Space Persistency](/xap101/hibernate-space-persistency.html) |
-|[Cassandra](http://cassandra.apache.org/)  | 1.1.6 | [Apache2](http://www.apache.org/licenses/LICENSE-2.0.html) |Persistency | [Cassandra Integration](/xap101/cassandra.html) |
-|[MongoDB](http://www.mongodb.org/)         | 2.11.2 | [Creative Commons](http://creativecommons.org/licenses/by-nc-sa/3.0/) | Persistency | [MongoDB Integration](/xap101/mongodb.html) |
-|[InfluxDB](https://influxdata.com/) | 0.9 (As of 10.2.1, 0.8 for 10.2.0) | [MIT](https://influxdb.com/docs/v0.9/about/licenses.html) | Metrics | [InfluxDB](/xap102adm/metrics-influxdb-reporter.html) |
-|[Jetty](http://eclipse.org/jetty/)         | 8.1.8, 9.1.3 | [Apache2](http://www.eclipse.org/jetty/licenses.php) | Web Container | [Jetty Processing Unit Container](/xap101/web-jetty-processing-unit-container.html) |
-|[JMS](http://java.sun.com/products/jms/)   | 1.1 | [Sun](http://www.opensource.org/licenses/sunpublic.php) | JMS | [JMS Messaging Support](/xap101/messaging-support.html) |
-|[Mule](http://www.mulesoft.org/)           | 3.3.0 | [CPAL](http://www.mulesoft.org/licensing-mule-esb) | Mule | [Mule ESB](/xap100/mule-esb.html) |
-|[Groovy](http://groovy-lang.org/)          | 1.8.6 | [Apache2](http://svn.codehaus.org/groovy/trunk/groovy/groovy-core/LICENSE.txt) | Dynamic Scripting | [Dynamic Scripting Support](/xap101/dynamic-language-tasks.html)|
-|[Scala](http://www.scala-lang.org/)        | 2.10.1 | [Scala](http://www.scala-lang.org/license.html) | Scala | [Scala](/xap101/scala.html) |
-|[MapDB](http://www.mapdb.org/)             | 1.0.7 | [Apache2](https://github.com/jankotek/MapDB/blob/master/license.txt) | Off Heap | [Off Heap RAM](/xap101adm/memoryxtend-ohr.html) |
-|[snmp4j](http://www.snmp4j.org/)           | 1.11.2 | [Apache2](http://www.snmp4j.org/LICENSE-2_0.txt) | SNMP | [SNMP Connectivity via Alert Logging Gateway](/xap101/snmp-connectivity-via-alert-logging-gateway.html) |
-|[log4j-snmp-trap-appender](http://code.google.com/p/log4j-snmp-trap-appender/) | 1.2.9 | [Apache2](http://www.apache.org/licenses/LICENSE-2.0.html) | SNMP | [SNMP Connectivity via Alert Logging Gateway](/xap101/snmp-connectivity-via-alert-logging-gateway.html)  |
+|[OpenJPA](http://openjpa.apache.org/)      | 2.0.1 | [Apache2](http://openjpa.apache.org/license.html)          | Persistency | [JPA](/xap120/jpa-api-overview.html) |
+|[Hibernate](http://www.hibernate.org/orm/) | 4.1.9 | [LGPL](http://hibernate.org/community/license/)            | Persistency | [Hibernate Space Persistency](/xap120/hibernate-space-persistency.html) |
+|[Cassandra](http://cassandra.apache.org/)  | 1.1.6 | [Apache2](http://www.apache.org/licenses/LICENSE-2.0.html) |Persistency | [Cassandra Integration](/xap120/cassandra.html) |
+|[MongoDB](http://www.mongodb.org/)         | 2.11.2 | [Creative Commons](http://creativecommons.org/licenses/by-nc-sa/3.0/) | Persistency | [MongoDB Integration](/xap120/mongodb.html) |
+|[InfluxDB](https://influxdata.com/) | 0.9 (As of 10.2.1, 0.8 for 10.2.0) | [MIT](https://influxdb.com/docs/v0.9/about/licenses.html) | Metrics | [InfluxDB](/xap120adm/metrics-influxdb-reporter.html) |
+|[Jetty](http://eclipse.org/jetty/)         | 8.1.8, 9.1.3 | [Apache2](http://www.eclipse.org/jetty/licenses.php) | Web Container | [Jetty Processing Unit Container](/xap120/web-jetty-processing-unit-container.html) |
+|[JMS](http://java.sun.com/products/jms/)   | 1.1 | [Sun](http://www.opensource.org/licenses/sunpublic.php) | JMS | [JMS Messaging Support](/xap120/messaging-support.html) |
+|[Mule](http://www.mulesoft.org/)           | 3.3.0 | [CPAL](http://www.mulesoft.org/licensing-mule-esb) | Mule | [Mule ESB](/xap120/mule-esb.html) |
+|[Groovy](http://groovy-lang.org/)          | 1.8.6 | [Apache2](http://svn.codehaus.org/groovy/trunk/groovy/groovy-core/LICENSE.txt) | Dynamic Scripting | [Dynamic Scripting Support](/xap120/dynamic-language-tasks.html)|
+|[Scala](http://www.scala-lang.org/)        | 2.10.1 | [Scala](http://www.scala-lang.org/license.html) | Scala | [Scala](/xap120/scala.html) |
+|[MapDB](http://www.mapdb.org/)             | 1.0.7 | [Apache2](https://github.com/jankotek/MapDB/blob/master/license.txt) | Off Heap | [Off Heap RAM](/xap120adm/memoryxtend-ohr.html) |
+|[snmp4j](http://www.snmp4j.org/)           | 1.11.2 | [Apache2](http://www.snmp4j.org/LICENSE-2_0.txt) | SNMP | [SNMP Connectivity via Alert Logging Gateway](/xap120/snmp-connectivity-via-alert-logging-gateway.html) |
+|[log4j-snmp-trap-appender](http://code.google.com/p/log4j-snmp-trap-appender/) | 1.2.9 | [Apache2](http://www.apache.org/licenses/LICENSE-2.0.html) | SNMP | [SNMP Connectivity via Alert Logging Gateway](/xap120/snmp-connectivity-via-alert-logging-gateway.html)  |
 
 {{% /tab %}}
 


### PR DESCRIPTION
The version of hibernate XAP is dependent on was changed in 10.1 It has remained 4.1.9 since.

Also updated links to the documentation to match the version of the release note (i.e., if they are viewing version 12.0 release notes, they won't be taken back to version 10.1 documentation).