### PR TITLE
Update space-object-id-operations.markdown

### DIFF
--- a/site/content/xap120/space-object-id-operations.markdown
+++ b/site/content/xap120/space-object-id-operations.markdown
@@ -67,7 +67,7 @@ public class CompoundId implements Serializable{
 			return true;
 		if (obj == null)
 			return false;
-		if (getClass() != obj.getClass())
+		if (!(obj instanceof CompoundId)) 
 			return false;
 		CompoundId other = (CompoundId) obj;
 		if (key1 == null) {


### PR DESCRIPTION
might get false results when using  getClass() != obj.getClass() when multi class loaders are involved