### PR TITLE
Update memory-management-overview.markdown

### DIFF
--- a/site/content/xap/12.2/admin/lru-cache-policy.markdown
+++ b/site/content/xap/12.2/admin/lru-cache-policy.markdown
@@ -334,5 +334,5 @@ This happens since the JVM hosting the space might not perform garbage collectio
 When using the `space-config.engine.memory_usage.explicit-gc` option:
 
 - Make sure that `-XX:+DisableExplicitGC` isn't set.
-- Add `-XX:+ExplicitGCInvokesConcurrent` - this might help to reduce the impact of the `System.gc()` calls.
+- Add `-XX:+ExplicitGCInvokesConcurrent` - this might help to reduce the impact of the `System.gc()` calls (available when using Concurrent Mark Sweep).
 - Make sure that `System.gc()` is called before calculating available memory.

--- a/site/content/xap/12.2/admin/memory-management-overview.markdown
+++ b/site/content/xap/12.2/admin/memory-management-overview.markdown
@@ -56,7 +56,7 @@ The explicit garbage collection call reduces the probability of throwing `SpaceM
 To avoid this behavior, add one of the following to your client-side or Space-side JVM parameter list:
 
 - XX:+DisableExplicitGC<br>
-- XX:+ExplicitGCInvokesConcurrent
+- XX:+ExplicitGCInvokesConcurrent (only available when using Concurrent Mark Sweep) 
 
 {{% note "Note"%}}
 Only do this if you've determined that it is absolutely necessary, because it disables a feature designed to protect your application.


### PR DESCRIPTION
Added a small comment to remind readers ExplicitGCInvokesConcurrent is only available when using the Concurrent Mark Sweep GC algorithm. Previous versions may need to be updated too.